### PR TITLE
Update sgbd_syntax_mysql.php

### DIFF
--- a/lib/framework/sgbd/syntax/sgbd_syntax_mysql.php
+++ b/lib/framework/sgbd/syntax/sgbd_syntax_mysql.php
@@ -18,10 +18,10 @@ along with Mkframework.  If not, see <http://www.gnu.org/licenses/>.
 class sgbd_syntax_mysql{
 	
 	public static function getListColumn($sTable){
-		return 'SHOW COLUMNS FROM '.$sTable;
+		return 'SHOW COLUMNS FROM `'.$sTable.'`';
 	}
 	public static function getStructure($sTable){
-		return 'SHOW COLUMNS FROM '.$sTable;
+		return 'SHOW COLUMNS FROM `'.$sTable.'`';
 	}
 	public static function getListTable(){
 		return 'SHOW TABLES';


### PR DESCRIPTION
Add backquotes to table name.
Usefull when table name is equal to a MySQL keyword like "Order"
