### PR TITLE
Ajout de méthodes ORM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Created by .ignore support plugin (hsz.mobi)
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/
+

--- a/lib/framework/abstract/abstract_model.php
+++ b/lib/framework/abstract/abstract_model.php
@@ -267,8 +267,11 @@ abstract class abstract_model{
         return $query;
     }
 
-    public function checkFieldExists($data) {
-
+    public function checkFieldExists($fields) {
+        $rest = array_diff($fields, $this->getListColumn());
+        if (count($rest) > 0 ) {
+            throw new Exception('Propriétés inéxistante dans la table '.$this->sTable .' : '.implode(', ', $rest));
+        }
     }
 
     public function findBy($filters)

--- a/lib/framework/abstract/abstract_model.php
+++ b/lib/framework/abstract/abstract_model.php
@@ -240,5 +240,49 @@ abstract class abstract_model{
 		}
 		return self::$_tInstance[$class];
 	}
+
+    public function __call($name, $arguments)
+    {
+        if (substr($name, 0, 6) == 'findBy') {
+            $fieldname = strtolower(substr($name, 6));
+            return $this->findby([$fieldname => $arguments[0]]);
+        }
+        if (substr($name, 0, 9) == 'findOneBy') {
+            $fieldname = strtolower(substr($name, 9));
+            return $this->findOneBy([$fieldname => $arguments[0]]);
+        }
+    }
+
+    protected function getfindQuery($filters) {
+        $query = 'SELECT * FROM ' . $this->sTable;
+        $this->checkFieldExists(array_keys($filters));
+        if (count($filters) > 0) {
+            $where = array();
+            $keys = array_keys($filters);
+            foreach($keys as $key) {
+                $where[] = ''.$key.' = ?';
+            }
+            $query .= ' WHERE '. implode(' AND ', $where);
+        }
+        return $query;
+    }
+
+    public function checkFieldExists($data) {
+
+    }
+
+    public function findBy($filters)
+    {
+        $query = $this->getfindQuery($filters);
+        $tSql = [$query, array_shift($filters)];
+        return $tObj= $this->getSgbd()->findMany($tSql,$this->sClassRow);
+    }
+
+    public function findOneBy($filters)
+    {
+        $query = $this->getfindQuery($filters);
+        $tSql = [$query, array_shift($filters)];
+        return $tObj= $this->getSgbd()->findOne($tSql,$this->sClassRow);
+    }
 	
 }

--- a/lib/framework/abstract/abstract_model.php
+++ b/lib/framework/abstract/abstract_model.php
@@ -253,7 +253,7 @@ abstract class abstract_model{
         }
     }
 
-    protected function getfindQuery($filters) {
+    protected function getFindQuery($filters) {
         $query = 'SELECT * FROM ' . $this->sTable;
         $this->checkFieldExists(array_keys($filters));
         if (count($filters) > 0) {
@@ -276,14 +276,14 @@ abstract class abstract_model{
 
     public function findBy($filters)
     {
-        $query = $this->getfindQuery($filters);
+        $query = $this->getFindQuery($filters);
         $tSql = [$query, array_shift($filters)];
         return $tObj= $this->getSgbd()->findMany($tSql,$this->sClassRow);
     }
 
     public function findOneBy($filters)
     {
-        $query = $this->getfindQuery($filters);
+        $query = $this->getFindQuery($filters);
         $tSql = [$query, array_shift($filters)];
         return $tObj= $this->getSgbd()->findOne($tSql,$this->sClassRow);
     }


### PR DESCRIPTION
Bonjour,
Je me suis permis d'ajouter des méthodes permettant de faire les appels suivants :
```php
$model->findOneBy(['field'=>'value', ...]); // retourne un seul résultat correspondant à tous les filtres
$model->findBy(['field'=>'value', ...]); // retourne tous les résultats correspondant à tous les filtres
```
ou via la méthode magique __call (qui appelle en réalité les méthodes ci-dessus): 
```php
$model->findOneByField('value'); // retourne un seul résultat correspondant au filtre Field
$model->findByField('value'); // retourne tous les résultats correspondant au filtre Field
```
Dans tous les cas, la requête est généré automatiquement par abstract_model::getFindQuery() dans findOneBy() et findBy().

Ajout d'une méthode checkFieldsExist pour valider la liste des champs avant d’exécuter la requête.

J'ai également ajouté un fichier .gitignore pour ne pas commiter les fichiers spécifique à mon IDE.